### PR TITLE
Fix: Split serverMods string for symbols

### DIFF
--- a/src/RouteManager.ts
+++ b/src/RouteManager.ts
@@ -436,10 +436,21 @@ export class RouteManager {
         let profileName = staticProfile.characters.pmc.Info.Nickname;
         const kills = getStatValue(['KilledPmc']);
         const raidEndResult = this.sptLeaderboard.raidResult;
+
+        const rawServerMods = this.sptLeaderboard.serverMods;
+
+        let serverMods: string[];
+
+        if (typeof rawServerMods === "string") {
+            serverMods = rawServerMods.split(",").map(x => x.trim());
+        } else {
+            serverMods = rawServerMods;
+        }
+
         const combinedModData = [...this.sptLeaderboard.collectModData().userMods, 
                         ...this.sptLeaderboard.collectModData().bepinexMods,
                         ...this.sptLeaderboard.collectModData().bepinexDlls,
-                        ...this.sptLeaderboard.serverMods];
+                        ...serverMods];
         
         const isScavRaid = profile.Info.Side === "Savage";
 


### PR DESCRIPTION
List mods in request before fix: `["IhanaMies-LootValueBackend","SpecialSlots","SPT-Leaderboard","zSolarint-SAIN-ServerMod","DrakiaXYZ-Waypoints","kmyuhkyuk-GamePanelHUD","kmyuhkyuk-KmyTarkovApi","SAIN","spt","StashSearch","DrakiaXYZ-BigBrain.dll","dvize.AILimit.dll","Kat.FastSellInFlea.dll","LootInstantSearch.dll","LootValue.dll","SpecialSlots.dll","SPTVRAMCleaner.dll","Terkoiz.Skipper.dll","Tyfon.UIFixes.dll","Tyfon.UIFixes.Net.dll","L","o","o","t","V","a","l","u","e","B","a","c","k","e","n","d",","," ","S","p","e","c","i","a","l","S","l","o","t","s",","," ","S","A","I","N",","," ","S","P","T"," ","L","e","a","d","e","r","b","o","a","r","d"]`

List mods in request after fix: `["IhanaMies-LootValueBackend","SpecialSlots","SPT-Leaderboard","zSolarint-SAIN-ServerMod","DrakiaXYZ-Waypoints","kmyuhkyuk-GamePanelHUD","kmyuhkyuk-KmyTarkovApi","SAIN","spt","StashSearch","DrakiaXYZ-BigBrain.dll","dvize.AILimit.dll","Kat.FastSellInFlea.dll","LootInstantSearch.dll","LootValue.dll","SpecialSlots.dll","SPTVRAMCleaner.dll","Terkoiz.Skipper.dll","Tyfon.UIFixes.dll","Tyfon.UIFixes.Net.dll","LootValueBackend","SpecialSlots","SAIN","SPT Leaderboard"]`